### PR TITLE
sequences hash is duplicated when transform_write

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -4,4 +4,5 @@ require "bundler/setup"
 require_relative "../init"
 
 require "irb"
+require 'idempotence/sequential/controls'
 IRB.start(__FILE__)

--- a/lib/idempotence/sequential/controls/entity.rb
+++ b/lib/idempotence/sequential/controls/entity.rb
@@ -5,6 +5,12 @@ module Idempotence
         class SomeEntity
           include Schema::DataStructure
           include Idempotence::Sequential::EntitySequences
+
+          attr_reader :instance_transform_write_called
+
+          def transform_write(_data)
+            @instance_transform_write_called = true
+          end
         end
 
         def self.example
@@ -17,6 +23,16 @@ module Idempotence
 
         def self.id_increment
           5678
+        end
+
+        module WithSequences
+          def self.example
+            message = Controls::Message.example
+
+            entity = Entity.example
+            entity.record_sequence(message)
+            entity
+          end
         end
       end
     end

--- a/lib/idempotence/sequential/entity_sequences.rb
+++ b/lib/idempotence/sequential/entity_sequences.rb
@@ -3,6 +3,8 @@ module Idempotence
     module EntitySequences
       def self.included(cls)
         cls.class_exec do
+          prepend TransformWriteDupSequences
+
           include RecordSequence
           include MessageProcessed
 
@@ -34,6 +36,13 @@ module Idempotence
 
           message_sequence = message.metadata.global_position
           message_sequence <= category_sequence
+        end
+      end
+
+      module TransformWriteDupSequences
+        def transform_write(data)
+          super(data)
+          data[:sequences] = data[:sequences].dup
         end
       end
     end

--- a/test/automated/sequential/entity_sequences/transform_write.rb
+++ b/test/automated/sequential/entity_sequences/transform_write.rb
@@ -1,0 +1,26 @@
+require_relative '../../../test_init'
+
+context "Idempotence" do
+  context "Sequential" do
+    context "EntitySequences" do
+      context '#transform_write' do
+        entity = Controls::Entity::WithSequences.example
+        attributes = entity.attributes
+
+        context 'transform_write duplicates sequences' do
+          test 'has same values' do
+            assert attributes[:sequences] == entity.sequences
+          end
+
+          test 'is different object' do
+            refute attributes[:sequences].equal?(entity.sequences)
+          end
+        end
+
+        test "entity's transform_write is called" do
+          assert entity.instance_transform_write_called
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It will cause cloned instances to have own sequences hash object. It will allow create custom fixture to test sequencial idempotency.