### PR TITLE
adds sequence sanity check

### DIFF
--- a/lib/idempotence/sequential/entity_sequences.rb
+++ b/lib/idempotence/sequential/entity_sequences.rb
@@ -11,7 +11,8 @@ module Idempotence
       end
 
       module RecordSequence
-        class NoCausationMessageDetailsError < RuntimeError; end
+        NoCausationMessageDetailsError = Class.new(RuntimeError)
+        DecreasingSequenceError = Class.new(RuntimeError)
 
         def record_sequence(message)
           causation_message_stream_name = message.metadata.causation_message_stream_name
@@ -19,6 +20,8 @@ module Idempotence
 
           causation_category = Messaging::StreamName.get_category(causation_message_stream_name)
           causation_sequence = message.metadata.causation_message_global_position
+
+          raise DecreasingSequenceError if sequences[causation_category] &.> causation_sequence
 
           sequences[causation_category] = causation_sequence
         end

--- a/test/automated/sequential/entity_sequences/record_sequence.rb
+++ b/test/automated/sequential/entity_sequences/record_sequence.rb
@@ -12,7 +12,8 @@ context "Idempotence" do
 
         command_gp = 10
         event_issued_by_command_gp = command_gp + 1
-        event_issued_by_event_gp = event_issued_by_command_gp + 1
+        event_one_issued_by_event_gp = event_issued_by_command_gp + 1
+        event_two_issued_by_event_gp = event_one_issued_by_event_gp + 1
 
         initial_command = Controls::Message::WithoutCausation
           .example(metadata: { stream_name: command_stream_name, global_position: command_gp })
@@ -21,13 +22,18 @@ context "Idempotence" do
           stream_name: event_stream_name,
           global_position: event_issued_by_command_gp
         })
-        event_issued_by_event = Controls::Message.example(metadata: {
+        event_one_issued_by_event = Controls::Message.example(metadata: {
           stream_name: event_stream_name,
-          global_position: event_issued_by_event_gp
+          global_position: event_one_issued_by_event_gp
+        })
+        event_two_issued_by_event = Controls::Message.example(metadata: {
+          stream_name: event_stream_name,
+          global_position: event_two_issued_by_event_gp
         })
 
         event_issued_by_command.metadata.follow(initial_command.metadata)
-        event_issued_by_event.metadata.follow(event_issued_by_command.metadata)
+        event_one_issued_by_event.metadata.follow(event_issued_by_command.metadata)
+        event_two_issued_by_event.metadata.follow(event_one_issued_by_event.metadata)
 
         entity = Controls::Entity.example
 
@@ -54,13 +60,32 @@ context "Idempotence" do
         end
 
         context 'event issued by event' do
-          entity.record_sequence(event_issued_by_event)
+          entity.record_sequence(event_one_issued_by_event)
 
-          test 'records sequence for command category' do
+          test 'records sequence for event category' do
             assert entity.sequences == {
               command_category => command_gp,
               category => event_issued_by_command_gp
             }
+          end
+        end
+
+        context 'another event issued by event' do
+          entity.record_sequence(event_two_issued_by_event)
+
+          test 'updates sequence for event category' do
+            assert entity.sequences == {
+              command_category => command_gp,
+              category => event_one_issued_by_event_gp
+            }
+          end
+        end
+
+        context 'attempt to record sequence of earlier event' do
+          test 'raises decreasing sequence error' do
+            assert_raises EntitySequences::RecordSequence::DecreasingSequenceError do
+              entity.record_sequence(event_one_issued_by_event)
+            end
           end
         end
       end


### PR DESCRIPTION
Sequential idempotence work well only when it is a non-decreasing sequence. Attempt to write lower sequence, will cause likelihood to reprocessing of already processed messages, which violates idempotency