### PR TITLE
1.0.3 released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.3 - 2023-08-08]
+### Added
+- Adds sequence sanity check
+
+### Fixes
+- sequences hash is duplicated when transform_write
+
 ## [1.0.2 - 2023-05-10]
 ### Fixed
 - removes Schema::DataStructure from EntitySequences

--- a/hubbado-idempotence-sequential.gemspec
+++ b/hubbado-idempotence-sequential.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |spec|
   spec.name     = "hubbado-idempotence-sequential"
-  spec.version  = "1.0.2"
+  spec.version  = "1.0.3"
   spec.authors  = ["Alexander Repnikov"]
   spec.email    = ["aleksander.repnikov@gmail.com"]
 
   spec.summary  = "Idempotence library to handle sequential idempotence pattern in eventide toolkit"
   spec.homepage = "https://www.github.com/hubbado/hubbado-idempotence-sequential"
   spec.license  = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.1")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.2")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
adds Changelog:
- sanity check: guarantee sequence to be non-decreasing series
- sequences hash duplicated: instance dup/clone has his own object for sequnces

increases required ruby version: since new Eventide TestBench requires ruby to be 3.2+